### PR TITLE
Fix spacing in StructureController

### DIFF
--- a/includes/class.StructureController.inc.php
+++ b/includes/class.StructureController.inc.php
@@ -22,7 +22,7 @@ class StructureController extends BaseController
 	public function handle($args)
 	{
 	
-		require(WEB_ROOT . ' /structure.php');
+		require(WEB_ROOT . '/structure.php');
 
 		$this->render($content);
 		


### PR DESCRIPTION
Critical bug that will leave /browse/ blank, per #451 
