### PR TITLE
Comment out some Solr examples that give warnings on Solr start

### DIFF
--- a/solr_home/statedecoded/conf/solrconfig.xml
+++ b/solr_home/statedecoded/conf/solrconfig.xml
@@ -70,7 +70,7 @@
 
        The examples below can be used to load some solr-contribs along 
        with their external dependencies.
-    -->
+    
   <lib dir="../../../contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="../../../dist/" regex="solr-cell-\d.*\.jar" />
 
@@ -83,10 +83,11 @@
   <lib dir="../../../contrib/velocity/lib" regex=".*\.jar" />
   <lib dir="../../../dist/" regex="solr-velocity-\d.*\.jar" />
 
-  <!-- If a 'dir' option (with or without a regex) is used and nothing
+       If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, it will be ignored
-    -->
+    
   <lib dir="/total/crap/dir/ignored" /> 
+    -->
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a 
        specific jar file.  This will cause a serious error to be logged 


### PR DESCRIPTION
Something very very minor to avoid things like this when launching Solr:

`3468 [coreLoadExecutor-3-thread-1] WARN  org.apache.solr.core.SolrResourceLoader  – Can't find (or read) directory to add to classloader: ../../../dist/ (resolved as: /home/ubuntu/statedecoded/solr_home/statedecoded/../../../dist).
3468 [coreLoadExecutor-3-thread-1] WARN  org.apache.solr.core.SolrResourceLoader  – Can't find (or read) directory to add to classloader: ../../../contrib/clustering/lib/ (resolved as: /home/ubuntu/statedecoded/solr_home/statedecoded/../../../contrib/clustering/lib).`
