### PR TITLE
Added checking for empty structure labels and fixed spacing

### DIFF
--- a/htdocs/structure.php
+++ b/htdocs/structure.php
@@ -197,7 +197,7 @@ if(strlen($structure_id) > 0)
 		foreach ($structure as $level)
 		{
 		
-			if ($level->label !== $struct->label)
+			if ($level->label !== $struct->label && !empty($level->label))
 			{
 				$body .= ' It is part of ' . ucwords($level->label) . ' ' . $level->identifier . ', '
 				.'titled “' . $level->name . '.”';
@@ -308,7 +308,7 @@ $laws = $struct->list_laws();
 if ($laws !== FALSE)
 {
 
-	$body .= 'It’s comprised of the following ' . count((array) $laws) . ' sections.</p>';
+	$body .= ' It’s comprised of the following ' . count((array) $laws) . ' sections.</p>';
 	$body .= '<dl class="title-list laws">';
 
 	foreach ($laws as $law)


### PR DESCRIPTION
Under strange circumstances, $structure's first element is an object with only 'level' set. Thus, when the comparison `$level->label !== $struct->label` returns true because $level->label doesn't actually exist/is empty (not sure if isset should be used here), a blank label is returned.
