### PR TITLE
Lazy load ZeroClipboard swf when visible. #590

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,6 +22,8 @@ License, Version 2.0.
 jQuery ZeroClipboard v1.1.1 is copyright 2011, SteamDev, released under the MIT
 License.
 
+jQuery.inview is copyright 2009 Remy Sharp, released under the MIT License.
+
 Solarium is copyright 2011, Bas de Nooijer, released under the BSD License.
 
 Wherever fragmentary third-party code has been used, credit has been given in

--- a/htdocs/themes/StateDecoded2013/class.Page.inc.php
+++ b/htdocs/themes/StateDecoded2013/class.Page.inc.php
@@ -70,6 +70,11 @@ class StateDecoded2013__Page extends Page
 			'type' => 'javascript',
 			'requires' => array('jquery')
 		),
+		'jquery_inview' => array(
+			'path' => '/js/vendor/jquery.inview.min.js',
+			'type' => 'javascript',
+			'requires' => array('jquery')
+		),
 		'polyfiller' => array(
 			'path' => '/js/vendor/js-webshim/minified/polyfiller.js',
 			'type' => 'javascript'

--- a/htdocs/themes/StateDecoded2013/static/js/vendor/functions.js
+++ b/htdocs/themes/StateDecoded2013/static/js/vendor/functions.js
@@ -177,16 +177,23 @@ $(document).ready(function () {
     /* We want the port if it is set, so don't use hostname */
     base_url += document.location.host;
 
-	/* Get each permalink and add a copy function on it */
-	$('a.section-permalink').each(function(i, elm) {
-		var elm = $(elm);
+	/* Get each permalink and add a copy function on it when visible */
+	$('a.section-permalink').bind('inview', function(event, visible, topOrBottomOrBoth) {
+		if(!visible) return false;
+
+		var elm = $(this);
 		var id = escapeSelector(elm.attr('id'));
 
-		/* Permit copying URLs to the clipboard. */
-		elm.zclip({
-			path: zclip_swf_file,
-			copy: function() { return base_url + $(this).attr('href'); }
-		});
+		if(!elm.data('copyable')){
+			/* Permit copying URLs to the clipboard. */
+			elm.zclip({
+				path: zclip_swf_file,
+				copy: function() { return base_url + $(this).attr('href'); }
+			});
+
+			/* Ensure zclip only run once per element */
+			elm.data('copyable', true);
+		}
 	});
 
 	/* Mentions of other sections of the code. */

--- a/htdocs/themes/StateDecoded2013/static/js/vendor/jquery.inview.min.js
+++ b/htdocs/themes/StateDecoded2013/static/js/vendor/jquery.inview.min.js
@@ -1,0 +1,7 @@
+/**
+ * author Remy Sharp
+ * url http://remysharp.com/2009/01/26/element-in-view-event-plugin/
+ * fork https://github.com/zuk/jquery.inview
+ */
+(function(e){function m(){var b=window.innerHeight;if(b)return b;var f=document.compatMode;if(f||!e.support.boxModel)b="CSS1Compat"===f?document.documentElement.clientHeight:document.body.clientHeight;return b}var n=function(b,f){function e(){null!==a?c=!0:(c=!1,b(),a=setTimeout(function(){a=null;c&&e()},f))}var c=!1,a=null;return e}(function(){var b=window.pageYOffset||document.documentElement.scrollTop||document.body.scrollTop,f=b+m(),g=[];e.each(e.cache,function(){this.events&&this.events.inview&&
+g.push(this.handle.elem)});e(g).each(function(){var c=e(this),a;a=0;for(var d=this;d;d=d.offsetParent)a+=d.offsetTop;var d=c.height(),k=a+d,d=c.data("inview")||!1,h=c.data("offset")||0,g=a>b&&k<f,l=k+h>b&&a<b,h=a-h<f&&k>f;g||l||h||a<b&&k>f?(a=h?"top":l?"bottom":"both",d&&d===a||(c.data("inview",a),c.trigger("inview",[!0,a]))):!g&&d&&(c.data("inview",!1),c.trigger("inview",[!1]))})},100);e(window).on("checkInView.inview click.inview ready.inview scroll.inview resize.inview",n)})(jQuery);


### PR DESCRIPTION
This waits until section permalinks are visible before loading ZeroClipboard on the element. Many elements will still be loaded if scrolling through the entire page, but not all at once.

An issue to watch is [ZeroClipboard's HTML5 Clipboard API](https://github.com/zeroclipboard/zeroclipboard/issues/171) support which should improve performance as well as compatibility with browsers that have Flash disabled.

In my configuration, ZeroClipboard.swf is cached so the network transfer isn't slow, but loading many Flash elements certainly is: ![zero-clipboard](https://cloud.githubusercontent.com/assets/11573/10774808/fb4761aa-7cd9-11e5-9787-8bda0ba8a2a2.png)