### PR TITLE
Unit test updates

### DIFF
--- a/includes/test/APITest.php
+++ b/includes/test/APITest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This suite of tests verifies API functionality.
+ */
+
+require_once './helper/class.TestDbHelper.inc.php';
+
+class APITest extends PHPUnit_Framework_TestCase
+{
+	protected function setUp()
+	{
+		/* API uses global $db */
+		global $db;
+
+		if(!$db)
+		{
+			$options = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT);
+			$db = new Database( PDO_DSN, PDO_USERNAME, PDO_PASSWORD, $options );
+		}
+
+		$logger = new Logger();
+
+		$parser = new ParserController(
+			array(
+				'logger' => $logger,
+				'db' => &$db,
+				'import_data_dir' => IMPORT_DATA_DIR));
+
+
+		$this->dbHelper = new TestDbHelper(
+			array(
+				'db' => &$db,
+				'logger' => $logger,
+				'parser' => $parser));
+
+		$this->dbHelper->setupDb();
+	}
+
+	protected function teardown()
+	{
+		$this->dbHelper->destroyDb();
+	}
+
+	/**
+	 * API Class Tests
+	 */
+
+	public function testRegisterKey()
+	{
+		$api = new API();
+		$api->suppress_activation_email = true;
+
+		/* Tests complain undefined property unless we initialize here */
+		$api->all_keys = new stdClass;
+
+		/* Form data would be set through $_POST */
+		$form = new stdClass;
+		$form->name = 'John Doe';
+		$form->email = 'jdoe@example.com';
+		$form->url = 'www.example.com';
+
+		$api->form = $form;
+
+		$api->register_key();
+		$api->list_all_keys();
+
+		$this->assertEmpty((array) $api->all_keys,
+			'Keys not set until activated');
+
+		$api->activate_key();
+		$api->list_all_keys();
+
+		$this->assertNotEmpty((array) $api->all_keys,
+			'Keys set once activated');
+	}
+}
+

--- a/includes/test/DatabaseTest.php
+++ b/includes/test/DatabaseTest.php
@@ -6,17 +6,6 @@
  * the connection without it.  We mock wherever possible.
  */
 
-/*
- * Create our include path.
- */
-if(!defined('INCLUDE_PATH'))
-{
-	define('INCLUDE_PATH', '../');
-}
-
-require_once '../config.inc.php';
-require_once '../functions.inc.php';
-
 class DatabaseTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()

--- a/includes/test/README.md
+++ b/includes/test/README.md
@@ -3,9 +3,18 @@
 Currently, The State Decoded has a *very* incomplete test suite.  There's some coverage
 for the Database wrapper, and not much else.  Feel free to contribute your own tests!
 
+Running the test suite _will delete data from the database_. For this reason, it is
+recommended a test database be configured. Copy `config.inc.php` to `config-test.inc.php`
+and adjust the configuration for the test database.
+
+You must also include the following in `config-test.inc.php` for the tests to run:
+
+    define('STATEDECODED_ENV', 'test');
+
 The Database wrapper contains a few functional tests, just to be safe.  One of those is
 for the timeout-reconnect error handler, so the test will take several seconds to run.
-It will also require a valid MySQL connection in `config.inc.php`.
+It will also require a valid MySQL connection in `config-test.inc.php`.
+
 
 ##Installation
 
@@ -31,4 +40,5 @@ directory.  Note: We're using a *very* simple relative path to resolve dependenc
 so you *must* run the test runner from within the test directory.
 
     cd includes/test/
-    phpunit ./
+    phpunit                     # run all tests
+    phpunit DatabaseTest.php    # run specific test

--- a/includes/test/bootstrap.php
+++ b/includes/test/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Note we're using config-test, not config.
+ */
+require_once '../config-test.inc.php';
+require_once '../functions.inc.php';
+
+/*
+ * This is a precaution against running tests that may be destructive.
+ *
+ * Hopefully proving the user read the warning in README.md and didn't just
+ * copy config.inc.php to config-test.inc.php unchanged. A different database
+ * configuration should be used for testing vs production.
+ */
+if(!defined('STATEDECODED_ENV') ||
+			 STATEDECODED_ENV !== 'test'){
+	echo "
+STATEDECODED_ENV must equal 'test'.
+
+See includes/test/README.md
+";
+	exit(1);
+}

--- a/includes/test/helper/class.TestDbHelper.inc.php
+++ b/includes/test/helper/class.TestDbHelper.inc.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Provides methods that can be added to setUp() and tearDown() to
+ * ensure the database is in a consistent state while testing.
+ */
+class TestDbHelper
+{
+
+	protected $db;
+	protected $logger;
+	protected $parser;
+
+	/*
+	 * @param array $options
+	 *
+	 * $options = array('db' => $db
+	 * 					'logger' => $logger,
+	 * 					'parser' => $parser)
+	 */
+	public function __construct($options)
+	{
+		$this->db = $options['db'];
+		$this->logger = $options['logger'];
+		$this->parser = $options['parser'];
+	}
+
+	/*
+	 * Populate the database and run migrations.
+	 *
+	 * Add to your TestCase setUp()
+	 */
+	public function setupDb()
+	{
+		if ($this->parser->test_environment() === FALSE)
+		{
+			return $this->assertTrue(false, 'There was an error testing the environment.');
+		}
+
+		if ($this->parser->populate_db() === FALSE)
+		{
+			return $this->assertTrue(false, 'There was an error populating the database.');
+		}
+
+		$this->parser->run_migrations();
+	}
+
+	/*
+	 * Delete database tables.
+	 *
+	 * Add to your TestCase tearDown()
+	 *
+	 * !!! Data will be lost, use with care. !!!
+	 */
+	public function destroyDb()
+	{
+		/* These functions are noisy, quiet log level */
+		$wasLevel = $this->logger->level;
+		$this->logger->level = 10;
+
+		$this->parser->clear_db();
+
+		/* api_keys not included in clear_db() */
+		$sql = 'DELETE FROM api_keys';
+		$statement = $this->db->prepare($sql);
+		$result = $statement->execute();
+
+		$this->parser->clear_index();
+
+		/* Return logging level */
+		$this->logger->level = $wasLevel;
+	}
+
+}

--- a/includes/test/phpunit.xml
+++ b/includes/test/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+  bootstrap="bootstrap.php"
+  backupGlobals="true">
+  <testsuites>
+    <testsuite name="Tests">
+      <directory suffix="Test.php">.*</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/includes/test/task/HelpActionTest.php
+++ b/includes/test/task/HelpActionTest.php
@@ -4,16 +4,6 @@
  * Help Action test suite
  */
 
-/*
- * Create our include path.
- */
-if(!defined('INCLUDE_PATH'))
-{
-	define('INCLUDE_PATH', '../../');
-}
-
-require_once '../config.inc.php';
-require_once '../functions.inc.php';
 require_once '../task/class.HelpAction.inc.php';
 
 class HelpActionTest extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
Here are some thoughts on testing for review:

[phpunit.xml](https://phpunit.de/manual/current/en/appendixes.configuration.html) and bootstrap.php are added for convenience.

A separate config-test.inc.php is required during tests. This is to ensure the main/production database is not affected by the tests.

To ensure a consistent db state between tests, TestDbHelper is able to reset the db at setUp() and tearDown(). See APITest for example usage.