### PR TITLE
Handle structures without identifiers.  Fixes #574 openva/va-decoded#22

### DIFF
--- a/htdocs/law.php
+++ b/htdocs/law.php
@@ -126,7 +126,16 @@ if (is_object($law->dublin_core))
 $content->set('breadcrumbs', '');
 foreach (array_reverse((array) $law->ancestry) as $ancestor)
 {
-	$content->append('breadcrumbs', '<li><a href="' . $ancestor->url . '">' . $ancestor->identifier
+	if(isset($ancestor->metadata->admin_division) && $ancestor->metadata->admin_division === TRUE)
+	{
+		$identifier = '';
+	}
+	else
+	{
+		$identifier = $ancestor->identifier . ': ';
+	}
+
+	$content->append('breadcrumbs', '<li><a href="' . $ancestor->permalink->url . '">' . $identifier
 		. ' ' . $ancestor->name . '</a></li>');
 }
 
@@ -178,7 +187,7 @@ $content->set('heading', '<nav class="prevnext" role="navigation"><ul>' .
 /*
  * Store the URL for the containing structural unit.
  */
-$content->append('link_rel', '<link rel="up" title="Up" href="' . $law->ancestry->{1}->url . '" />');
+$content->append('link_rel', '<link rel="up" title="Up" href="' . $law->ancestry[1]->url . '" />');
 
 /*
  * Start assembling the body of this page by indicating the beginning of the text of the section.

--- a/htdocs/structure.php
+++ b/htdocs/structure.php
@@ -42,7 +42,7 @@ else
 /*
  * Create a new instance of the class that handles information about individual laws.
  */
-$struct = new Structure();
+$struct = new Structure(array('db' => $db));
 
 if ( isset($args['edition_id']) )
 {
@@ -105,7 +105,7 @@ if (strlen($structure_id) > 0)
 else
 {
 	$content->set('browser_title', SITE_TITLE . ': The ' . LAWS_NAME . ', for Humans.');
-	$content->set('page_title', '<h2>'.ucwords($children->{0}->label) . 's of the ' . LAWS_NAME.'</h2>');
+	$content->set('page_title', '<h2>'.ucwords($children[0]->label) . 's of the ' . LAWS_NAME.'</h2>');
 }
 
 /*
@@ -129,8 +129,17 @@ if (count((array) $structure) > 1)
 			$active = 'active';
 		}
 
+		if(isset($level->metadata->admin_division) && $level->metadata->admin_division === TRUE)
+		{
+			$identifier = '';
+		}
+		else
+		{
+			$identifier = $level->identifier . ': ';
+		}
+
 		$content->append('breadcrumbs', '<li class="' . $active . '">
-				<a href="' . $level->url->url . '">' . $level->identifier . ': ' . $level->name . '</a>
+				<a href="' . $level->permalink->url . '">' . $identifier . $level->name . '</a>
 			</li>');
 
 		/*
@@ -291,7 +300,7 @@ if ($children !== FALSE)
 	/*
 	 * The level of this child structural unit is that of the current unit, plus one.
 	 */
-	$body .= '<dl class="title-list sections level-' . ((isset($structure->{count($structure)-1}->level) ? $structure->{count($structure)-1}->level : 0) + 1) . '">';
+	$body .= '<dl class="title-list sections level-' . ((isset($structure[count($structure)-1]->depth) ? $structure[count($structure)-1]->depth : 0) + 1) . '">';
 	foreach ($children as $child)
 	{
 
@@ -301,15 +310,22 @@ if ($children !== FALSE)
 		 */
 		$class_index = $counter % count($row_classes);
 		$row_class = $row_classes[$class_index];
-		$api_url = '/api/1.0/structure/' . $child->token
+		$api_url = '/api/1.0/structure/' . $child->permalink->token
 			 . '/?key=' . API_KEY;
-
-		$body .= '	<dt class="' . $row_class . '"><a href="' . $child->url . '"
-				data-identifier="' . $child->token . '"
+		if(isset($child->metadata->admin_division) && $child->metadata->admin_division === TRUE)
+		{
+			$identifier = '';
+		}
+		else
+		{
+			$identifier = $child->identifier;
+		}
+		$body .= '	<dt class="' . $row_class . '"><a href="' . $child->permalink->url . '"
+				data-identifier="' . $child->permalink->token . '"
 				data-api-url="' . $api_url . '"
-				>' . $child->identifier . '</a></dt>
-			<dd class="' . $row_class . '"><a href="' . $child->url . '"
-				data-identifier="' . $child->token . '"
+				>' . $identifier . '</a></dt>
+			<dd class="' . $row_class . '"><a href="' . $child->permalink->url . '"
+				data-identifier="' . $child->permalink->token . '"
 				data-api-url="' . $api_url . '"
 				>' . $child->name . '</a></dd>';
 

--- a/includes/class.Dictionary.inc.php
+++ b/includes/class.Dictionary.inc.php
@@ -268,22 +268,21 @@ class Dictionary
 		{
 			$this->generic_terms = TRUE;
 		}
-		
+
 		/*
 		 * Create an object in which we'll store terms that are identified.
 		 */
 		$terms = new stdClass();
-		
+
 		/*
 		 * Get a listing of all structural units that contain the current structural unit -- that is,
 		 * if this is a chapter, get the ID of both the chapter and the title. And so on.
 		 */
 		if (isset($this->structure_id))
 		{
-		
+
 			$heritage = new Structure;
-			$heritage->id = $this->structure_id;
-			$ancestry = $heritage->id_ancestry();
+			$ancestry = $heritage->id_ancestry($this->structure_id);
 			$tmp = array();
 			foreach ($ancestry as $level)
 			{

--- a/includes/class.Law.inc.php
+++ b/includes/class.Law.inc.php
@@ -266,26 +266,9 @@ class Law
 			$struct = new Structure;
 
 			/*
-			 * Provide the edition ID so that we know which edition to query.
-			 */
-			if (isset($this->edition_id))
-			{
-				$struct->edition_id = $this->edition_id;
-			}
-			else
-			{
-				$struct->edition_id = EDITION_ID;
-			}
-
-			/*
-			 * Our structure ID provides a starting point to identify this law's ancestry.
-			 */
-			$struct->id = $this->structure_id;
-
-			/*
 			 * Save the law's ancestry.
 			 */
-			$this->ancestry = $struct->id_ancestry();
+			$this->ancestry = $struct->id_ancestry($this->structure_id);
 
 			/*
 			 * Short of a parser error, there’s no reason why a law should not have an ancestry. In

--- a/includes/class.State-sample.inc.php
+++ b/includes/class.State-sample.inc.php
@@ -1175,10 +1175,16 @@ class Parser
 				{
 					$structure->identifier = $struct->name;
 					$structure->metadata->admin_division = TRUE;
+					/* We almost always want administrative divisions before regular divisions.*/
+					$structure->order_by = 0;
 				}
 				else
 				{
 					$structure->identifier = $struct->identifier;
+					if(!isset($structure->order_by))
+					{
+						$structure->order_by = 1;
+					}
 				}
 
 				$structure->name = $struct->name;
@@ -1695,6 +1701,11 @@ class Parser
 		{
 			$sql .= ', metadata = :metadata';
 			$sql_args[':metadata'] = serialize($this->metadata);
+		}
+		if(isset($this->order_by))
+		{
+			$sql .= ', order_by = :order_by';
+			$sql_args[':order_by'] = $this->order_by;
 		}
 
 		$statement = $this->db->prepare($sql);

--- a/includes/class.Structure.inc.php
+++ b/includes/class.Structure.inc.php
@@ -40,12 +40,6 @@ class Structure
 	 */
 	function url_to_structure()
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
 		/*
 		 * If we haven't been provided with a URL, let's just assume that it's the current one.
 		 */
@@ -79,7 +73,7 @@ class Structure
 		 */
 		$permalink_sql = 'SELECT relational_id FROM permalinks WHERE url = :url';
 		$permalink_args = array('url' => $this->path);
-		$permalink_statement = $db->prepare($permalink_sql);
+		$permalink_statement = $this->db->prepare($permalink_sql);
 
 		$result = $permalink_statement->execute($permalink_args);
 
@@ -112,15 +106,9 @@ class Structure
 	 */
 	function token_to_structure($token)
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
 		$permalink_sql = 'SELECT relational_id FROM permalinks WHERE token = :token';
 		$permalink_args = array(':token' => $token);
-		$permalink_statement = $db->prepare($permalink_sql);
+		$permalink_statement = $this->db->prepare($permalink_sql);
 
 		$result = $permalink_statement->execute($permalink_args);
 
@@ -156,11 +144,6 @@ class Structure
 	{
 
 		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
-		/*
 		 * If we don't have an ID of the structure element that we're looking for, then there's
 		 * really nothing for us to do here.
 		 */
@@ -169,129 +152,7 @@ class Structure
 			return false;
 		}
 
-		/*
-		 * Retrieve this structural unit's ancestry.
-		 */
-		$sql = 'SELECT structure_unified.*,
-				structure.edition_id
-				FROM structure_unified
-				LEFT JOIN structure ON structure_unified.s1_id = structure.id
-				WHERE
-				s1_id = :id
-				LIMIT 1';
-		$sql_args = array(
-			':id' => $this->structure_id
-		);
-		$statement = $db->prepare($sql);
-
-
-		$result = $statement->execute($sql_args);
-
-		if ( ($result === FALSE) || ($statement->rowCount() == 0) )
-		{
-			return FALSE;
-		}
-
-		/*
-		 * Get the result as an object.
-		 */
-		$structure_row = $statement->fetch(PDO::FETCH_OBJ);
-
-		$this->edition_id = $structure_row->edition_id;
-
-		/*
-		 * Pivot this into a multidimensional object. That is, it's presently stored in multiple
-		 * columns in a single row, but we want it in multiple rows, one per hierarchical level.
-		 */
-		$structure = new stdClass();
-		$structure_ids = array();
-
-		foreach($structure_row as $key => $value)
-		{
-			$value = stripslashes($value);
-
-			/*
-			 * Determine the table prefix name, so that we can use the number contained within it as
-			 * the object element name.
-			 */
-			$tmp = explode('_', $key);
-			$tmp = $tmp[0];
-			$prefix = str_replace('s', '', $tmp);
-			unset($tmp);
-
-			/*
-			 * Strip out the table prefix from the key name.
-			 */
-			$key = preg_replace('/s[0-9]_/', '', $key);
-
-			if ( ($key == 'id') )
-			{
-				/*
-				 * If we have a null value for an ID, then we've reached the end of the populated
-				 * columns in this row.
-				 */
-				if (empty($value))
-				{
-					break;
-				}
-				/*
-				 * Otherwise, keep track of the ids we've seen.
-				 */
-				else
-				{
-					$structure_ids[] = $value;
-				}
-			}
-
-			if ( !isset($structure->{$prefix-1}) )
-			{
-				$structure->{$prefix-1} = new StdClass();
-			}
-			$structure->{$prefix-1}->$key = $value;
-
-		}
-
-		$permalink_obj = new Permalink(array('db' => $db));
-		$this->permalink = $permalink_obj->get_preferred($this->structure_id, 'structure', $this->edition_id);
-
-		/*
-		 * Reverse the order of the elements of this object and place it in the scope of $this.
-		 */
-		$j=0;
-
-		if (!isset($this->structure) )
-		{
-			$this->structure = new StdClass();
-		}
-
-		for ($i=count((array) $structure)-1; $i>=0; $i--)
-		{
-
-			if(isset($structure->{$i}))
-			{
-				$this->structure->{$j} = $structure->{$i};
-
-				/*
-				 * Include the level of this structural element. (e.g., in Virginia, "title" is 1,
-				 * "chapter" is 2, "part" is 3.)
-				 */
-				$this->structure->{$j}->level = $j+1;
-
-				$temp_permalink = $permalink_obj->get_preferred($structure->{$i}->id, 'structure', $this->edition_id);
-
-				$this->structure->{$j}->url = $temp_permalink;
-				$this->structure->{$j}->token = $temp_permalink;
-
-				if (isset($prior_id))
-				{
-					$this->structure->{$j}->parent_id = $prior_id;
-				}
-				$j++;
-				$prior_id = $structure->{$i}->id;
-			}
-		}
-
-		unset($structure);
+		$this->structure = array_reverse($this->id_ancestry($this->structure_id));
 
 		/*
 		 * We set these variables for the convenience of other functions in this class.
@@ -301,31 +162,14 @@ class Structure
 		$this->label = $tmp->label;
 		$this->name = $tmp->name;
 		$this->identifier = $tmp->identifier;
+		$this->permalink = $tmp->permalink;
+		$this->metadata = $tmp->metadata;
 		if (isset($tmp->parent_id))
 		{
 			$this->parent_id = $tmp->parent_id;
 		}
 		unset($tmp);
 
-		/*
-		 * Get any metadata available about this structural unit.
-		 */
-		$sql = 'SELECT metadata
-				FROM structure
-				WHERE id=:id
-				AND metadata IS NOT NULL';
-		$sql_args = array(
-			':id' => $this->id
-		);
-
-		$statement = $db->prepare($sql);
-		$result = $statement->execute($sql_args);
-
-		if ( ($result !== FALSE) && ($statement->rowCount() >= 1) )
-		{
-			$structure_row = $statement->fetch(PDO::FETCH_OBJ);
-			$this->metadata = unserialize(stripslashes($structure_row->metadata));
-		}
 
 		/*
 		 * Get a list of all sibling structural units.
@@ -395,7 +239,7 @@ class Structure
 
 		}
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
 		$result = $statement->execute($sql_args);
 
 		/*
@@ -423,18 +267,11 @@ class Structure
 	 */
 	function list_children()
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
 		/*
 		 * Assemble the SQL query. The subselect is to avoid getting structural units that contain
 		 * only repealed (that is, unlisted) laws.
 		 */
-		$sql = 'SELECT structure_unified.*,
-				permalinks.url, permalinks.token';
+		$sql = 'SELECT structure_unified.*';
 
 		/*
 		 * If we're ordering by views, select that data.
@@ -447,10 +284,7 @@ class Structure
 		$sql .= '
 				FROM structure
 				LEFT JOIN structure_unified
-					ON structure.id = structure_unified.s1_id
-				LEFT JOIN permalinks
-					ON structure.id = permalinks.relational_id and
-					object_type = :object_type';
+					ON structure.id = structure_unified.s1_id';
 
 		/*
 		 * If we're ordering children by views, we need to join the structural table to the
@@ -464,15 +298,12 @@ class Structure
 							ON laws.section = laws_views.section';
 		}
 
-		$sql_args = array(
-			':object_type' => 'structure'
-		);
+		$sql_args = array();
 
 		/*
 		 * Check edition.
 		 */
 		$sql .= ' WHERE structure.edition_id = :edition_id';
-		$sql .= ' AND permalinks.preferred = 1';
 		if(isset($this->edition_id))
 		{
 			$sql_args[':edition_id'] = $this->edition_id;
@@ -548,7 +379,7 @@ class Structure
 				ABS(SUBSTRING_INDEX(structure.identifier, ".", -1)) ASC';
 		}
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
 		$result = $statement->execute($sql_args);
 
 		/*
@@ -560,9 +391,9 @@ class Structure
 		}
 
 		/*
-		 * Instantiate the object we'll use to store and return the list of child structures.
+		 * Instantiate the array we'll use to store and return the list of child structures.
 		 */
-		$children = new stdClass();
+		$children = array();
 
 		/*
 		 * Return the result as an object, built up as we loop through the results.
@@ -570,26 +401,7 @@ class Structure
 		$i=0;
 		while ($child = $statement->fetch(PDO::FETCH_OBJ))
 		{
-
-			/*
-			 * Remap the structural column names to simplified column names.
-			 */
-			$child->id = $child->s1_id;
-			$child->label = $child->s1_label;
-			$child->name = $child->s1_name;
-			$child->identifier = $child->s1_identifier;
-
-			/*
-			 *We don't need to display the aggregate view count -- we only use that for sorting.
-			 */
-			unset($child->view_count);
-
-			/*
-			 * Append this child to our list.
-			 */
-			$children->$i = $child;
-			$i++;
-
+			$children[] = $this->get_by_id($child->s1_id);
 		}
 
 		return $children;
@@ -602,21 +414,8 @@ class Structure
 	 * the chapter's ID, identifier, and name, along with its containing title's ID, number, and
 	 * name.
 	 */
-	function id_ancestry()
+	function id_ancestry($id)
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
-		/*
-		 * If a structural ID hasn't been passed to this function, then there's nothing to do.
-		 */
-		if (!isset($this->id))
-		{
-			return FALSE;
-		}
 
 		/*
 		 * We use SELECT * because it's ultimately more efficient. That's because structure_unified
@@ -628,10 +427,11 @@ class Structure
 				FROM structure_unified
 				WHERE s1_id = :id';
 		$sql_args = array(
-			':id' => $this->id
+			':id' => $id
 		);
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
+
 		$result = $statement->execute($sql_args);
 
 		if ( ($result === FALSE) || ($statement->rowCount() == 0) )
@@ -639,17 +439,17 @@ class Structure
 			return FALSE;
 		}
 
-		$structure = $statement->fetch(PDO::FETCH_OBJ);
+		$structure_row = $statement->fetch(PDO::FETCH_OBJ);
 
 		/*
 		 * Create a new, blank object.
 		 */
-		$ancestry = new stdClass();
+		$structure = array();
 
 		/*
 		 * Iterate through $structure, cell by cell.
 		 */
-		foreach ($structure as $column => $cell)
+		foreach ($structure_row as $key => $value)
 		{
 
 			/*
@@ -658,69 +458,48 @@ class Structure
 			 * the string's length because 0 evaluates as empty in PHP, and we want to allow the use
 			 * of 0 as a valid structural unit identifier.
 			 */
-			if (empty($cell) && (strlen($cell) == 0))
+			if (empty($value))
 			{
 				continue;
 			}
 
-			/*
-			 * The first three characters of the column name are the prefix.
-			 */
-			$prefix = substr($column, 0, 2);
+			$value = stripslashes($value);
 
 			/*
-			 * Strip out everything but the number.
+			 * Determine the table prefix name, so that we can use the number contained within it as
+			 * the object element name.
 			 */
-			$prefix = preg_replace('/[^0-9]/', '', $prefix);
+			$tmp = explode('_', $key);
+			$prefix = ltrim($tmp[0], 's');
+			$key = $tmp[1];
+			unset($tmp);
 
-			/*
-			 * Assign this datum to an element within $tmp based on its prefix.
-			 */
-			$label = substr($column, 3);
-
-			if(!isset($ancestry->$prefix))
+			if ( $key === 'id' )
 			{
-				$ancestry->$prefix = new StdClass();
-			}
 
-			$ancestry->$prefix->$label = $cell;
+				/*
+				 * If we have a null value for an ID, then we've reached the end of the populated
+				 * columns in this row.
+				 */
+				if (empty($value))
+				{
+					break;
+				}
+				/*
+				 * Otherwise, keep track of the ids we've seen.
+				 */
+				else
+				{
+					$structure_ids[] = $value;
+					/*
+					 * Get everything about this structure.
+					 */
+					$structure[$prefix-1] = $this->get_by_id($value);
+				}
+			}
 		}
 
-		/*
-		 * Go get our urls from the permalinks table.
-		 */
-		$sql = 'SELECT permalinks.url
-				FROM permalinks
-				WHERE relational_id = :id
-				AND preferred = 1
-				AND object_type = :object_type';
-		$statement = $db->prepare($sql);
-
-		foreach ((array) $ancestry as $key => $level)
-		{
-
-			$sql_args = array(
-				':id' => $ancestry->$key->id,
-				':object_type' => 'structure'
-			);
-
-			$result = $statement->execute($sql_args);
-
-			if ( ($result !== FALSE) && ($statement->rowCount() > 0) )
-			{
-				$permalink = $statement->fetch(PDO::FETCH_OBJ);
-
-				$ancestry->$key->url = $permalink->url;
-			}
-
-		}
-
-		unset($structure);
-		unset($label);
-		unset($cell);
-		unset($row);
-		return $ancestry;
-
+		return $structure;
 	}
 
 
@@ -729,12 +508,6 @@ class Structure
 	 */
 	function id_to_identifier()
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
 		/*
 		 * If a structural ID hasn't been passed to this function, then there's nothing to do.
 		 */
@@ -753,7 +526,7 @@ class Structure
 			':id' => $this->id
 		);
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
 		$result = $statement->execute($sql_args);
 
 
@@ -774,12 +547,6 @@ class Structure
 	 */
 	function identifier_to_id()
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
-
 		/*
 		 * If a structural identifier hasn't been passed to this function, then there's nothing to
 		 * do.
@@ -801,7 +568,7 @@ class Structure
 			':edition_id' => $this->edition_id
 		);
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
 		$result = $statement->execute($sql_args);
 
 
@@ -822,11 +589,6 @@ class Structure
 	 */
 	function list_laws()
 	{
-
-		/*
-		 * We're going to need access to the database connection throughout this class.
-		 */
-		global $db;
 
 		/*
 		 * If a structural ID hasn't been passed to this function, then there's nothing to do.
@@ -883,7 +645,7 @@ class Structure
 			);
 		}
 
-		$statement = $db->prepare($sql);
+		$statement = $this->db->prepare($sql);
 		$result = $statement->execute($sql_args);
 
 		if ( ($result === FALSE) || ($statement->rowCount() == 0) )
@@ -945,6 +707,41 @@ class Structure
 		else
 		{
 			return $statement->fetchAll();
+		}
+	}
+
+	public function get_by_id($id)
+	{
+		static $statement;
+		if(!$statement)
+		{
+			$query = 'SELECT *
+				FROM structure
+				WHERE id = :id';
+			$statement = $this->db->prepare($query);
+		}
+
+		$query_args = array(
+			':id' => $id
+		);
+		$result = $statement->execute($query_args);
+
+		if($result)
+		{
+			$structure = $statement->fetch(PDO::FETCH_OBJ);
+
+			if($structure->metadata)
+			{
+				$structure->metadata = unserialize($structure->metadata);
+			}
+
+			$permalink_obj = new Permalink(array('db' => $this->	db));
+			$structure->permalink = $permalink_obj->get_preferred($structure->id, 'structure', $structure->edition_id);
+
+			return $structure;
+		}
+		else {
+			return FALSE;
 		}
 	}
 


### PR DESCRIPTION
#574 openva/va-decoded#22

This also is a massive cleanup of the structure class, to reduce the magic and sprawling code.  In particular:

* Removes magic global $db
* Prefers passing in arguments to functions over context-specific magic properties.
* Removes duplicate code in ancestor handling between id_ancestry and get_current
* Replaces url mangling with a consistent interface to permalinks
* Replaces inconsistent, renamed properties with standard internal naming
* Eliminates abusing objects as arrays for real arrays.