### PR TITLE
Issue 703

### DIFF
--- a/htdocs/structure.php
+++ b/htdocs/structure.php
@@ -327,7 +327,7 @@ if ($children !== FALSE)
 		}
 		else
 		{
-			$identifier = $child->identifier;
+			$identifier = ucwords($child->label) . ' ' . $child->identifier;
 		}
 		$body .= '<tr><td><a href="' . $child->permalink->url . '"
 				data-identifier="' . $child->permalink->token . '"

--- a/includes/class.ParserController.inc.php
+++ b/includes/class.ParserController.inc.php
@@ -829,10 +829,21 @@ class ParserController
 		$result = $statement->execute();
 
 		/*
-		 * The depth of the structure is the number of entries in the structure labels,
-		 * minus one for 'section'.
+		 * Get the depth of our structures.
 		 */
-		$structure_depth = count($parser->get_structure_labels($this->edition_id))-1;
+		$sql = 'SELECT MAX(depth) AS depth FROM structure';
+		$statement = $this->db->prepare($sql);
+		$result = $statement->execute();
+
+		if($result)
+		{
+			$structure_depth = $statement->fetchColumn();
+		}
+		else
+		{
+			throw new Exception('Cannot get depth of structures.');
+		}
+
 
 		$select = array();
 		$from = array();


### PR DESCRIPTION
This needs a bit of testing.  Also the diff is pretty useless to explain what's happening here.

In short, I've completely cut out the `get_structure_labels` code. I've removed all the juggling of the structure labels into arrays of strings back and forth in favor of just using the list of structures itself.  If we find a match, the scope is then an actual structure object, so we don't have to duplicate our lookups a second time to find what scope that is, as we were doing previously.

#703