### PR TITLE
Fix queries to arrays to instead query objects

### DIFF
--- a/htdocs/law.php
+++ b/htdocs/law.php
@@ -215,7 +215,7 @@ $content->set('heading', '<nav class="prevnext" role="navigation"><ul>' .
 /*
  * Store the URL for the containing structural unit.
  */
-$content->append('link_rel', '<link rel="up" title="Up" href="' . $laws[0]->ancestry[1]->url . '" />');
+$content->append('link_rel', '<link rel="up" title="Up" href="' . $laws->{0}->ancestry[1]->url . '" />');
 
 $body = '';
 if(count($laws) > 1) {

--- a/htdocs/structure.php
+++ b/htdocs/structure.php
@@ -105,7 +105,7 @@ if (strlen($structure_id) > 0)
 else
 {
 	$content->set('browser_title', SITE_TITLE . ': The ' . LAWS_NAME . ', for Humans.');
-	$content->set('page_title', '<h2>'.ucwords($children[0]->label) . 's of the ' . LAWS_NAME.'</h2>');
+	$content->set('page_title', '<h2>'.ucwords($children->{0}->label) . 's of the ' . LAWS_NAME.'</h2>');
 }
 
 /*

--- a/htdocs/structure.php
+++ b/htdocs/structure.php
@@ -312,7 +312,7 @@ if ($children !== FALSE)
 	/*
 	 * The level of this child structural unit is that of the current unit, plus one.
 	 */
-	$body .= '<table class="title-list sections table-striped level-' . ((isset($structure[count($structure)-1]->depth) ? $structure[count($structure)-1]->depth : 0) + 1) . '"><tbody>';
+	$body .= '<table class="title-list sections table-striped level-' . ((isset($structure->{count($structure)-1}->depth) ? $structure->{count($structure)-1}->depth : 0) + 1) . '"><tbody>';
 	foreach ($children as $child)
 	{
 


### PR DESCRIPTION
These allow structural elements and laws to be retrieved and displayed without throwing errors. This closes #708.