### PR TITLE
Fix definition lookups. #717

### DIFF
--- a/htdocs/law.php
+++ b/htdocs/law.php
@@ -223,7 +223,8 @@ foreach($laws as $i=>$law)
 	/*
 	 * Start assembling the body of this page by indicating the beginning of the text of the section.
 	 */
-	$body .= '<article class="law-contents" id="law-' . $law->law_id . '">';
+	$body .= '<article class="law-contents" id="law-' . $law->law_id . '" data-law-id="' . $law->law_id . '"' .
+		' data-edition-id="' . $law->edition_id . '">';
 
 	$body .= '<h1>
 		<span class="section_id">' . SECTION_SYMBOL .' ' . $law->section_number . '</span>

--- a/htdocs/themes/StateDecoded2013/static/js/vendor/functions.js
+++ b/htdocs/themes/StateDecoded2013/static/js/vendor/functions.js
@@ -289,8 +289,16 @@ $(document).ready(function () {
 
 	/* Words for which we have dictionary terms.*/
 	$("span.dictionary").each(function() {
-		var term = $(this).text();
-		$(this).qtip({
+		var elm = $(this);
+
+		var container = elm.closest('article.law-contents');
+		var lawid = container.data('law-id');
+		var editionid = container.data('edition-id');
+
+		// Search the ancestors of this element until we find a law; get the id from that.
+
+		var term = elm.text();
+		elm.qtip({
 			tip: true,
 			hide: {
 				when: 'mouseout',
@@ -311,8 +319,8 @@ $(document).ready(function () {
 					url: '/api/dictionary/' + encodeURI(term) + '/',
 					type: 'GET',
 					data: {
-						law_id: law_id,
-						edition_id: edition_id,
+						law_id: lawid,
+						edition_id: editionid,
 						key: api_key
 					},
 					dataType: 'json',


### PR DESCRIPTION
Instead of using a global law_id and edition_id, we bolt this data onto the law's container article, then just ascend the tree when we need to look this information up.