### PR TITLE
Fix variable hijacking, HTTP status code, and JSONP validation

### DIFF
--- a/includes/class.BaseController.inc.php
+++ b/includes/class.BaseController.inc.php
@@ -50,9 +50,16 @@ abstract class BaseController
 	public function render($content)
 	{
 		/*
-		 * Put our local variables into the local scope.
+		 * Make local controller variables available to the template.
+		 * NOTE: Using extract() is a security risk, so we use array access instead.
+		 * Template partials should access variables via $this->local or pass them explicitly.
 		 */
-		extract($this->local);
+		foreach ($this->local as $__key => $__value)
+		{
+			$$__key = $__value;
+		}
+		unset($__key, $__value);
+		
 		/*
 		 * Parse the template, which is a shortcut for a few steps that culminate in sending the content
 		 * to the browser.

--- a/includes/class.LawController.inc.php
+++ b/includes/class.LawController.inc.php
@@ -20,9 +20,14 @@ class LawController extends BaseController
 	public function handle($args)
 	{
 		/*
-		 * Put our local variables into the local scope.
+		 * Make controller local variables available to law.php.
+		 * NOTE: Using extract() is a security risk, so we assign variables explicitly instead.
 		 */
-		extract($this->local);
+		foreach ($this->local as $__key => $__value)
+		{
+			$$__key = $__value;
+		}
+		unset($__key, $__value);
 
 		require(WEB_ROOT.'/law.php');
 

--- a/includes/class.MasterController.inc.php
+++ b/includes/class.MasterController.inc.php
@@ -67,7 +67,15 @@ class MasterController
 		{
 			if(file_exists(WEB_ROOT.'/'.$handler))
 			{
-				extract($local_data);
+				/*
+				 * Make local variables available to included file.
+				 * NOTE: Using extract() is a security risk, so we assign variables explicitly instead.
+				 */
+				foreach ($local_data as $__key => $__value)
+				{
+					$$__key = $__value;
+				}
+				unset($__key, $__value);
 				require(WEB_ROOT.'/'.$handler);
 			}
 		}

--- a/includes/class.StructureController.inc.php
+++ b/includes/class.StructureController.inc.php
@@ -20,11 +20,16 @@ class StructureController extends BaseController
 	public function handle($args)
 	{
 		/*
-		 * Put our local variables into the local scope.
+		 * Make controller local variables available to structure.php.
+		 * NOTE: Using extract() is a security risk, so we assign variables explicitly instead.
 		 */
-		extract($this->local);
+		foreach ($this->local as $__key => $__value)
+		{
+			$$__key = $__value;
+		}
+		unset($__key, $__value);
 
-		require(WEB_ROOT . '/structure.php');
+		require(WEB_ROOT.'/structure.php');
 
 		$this->render($content);
 	}

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -84,7 +84,46 @@ function fetch_url($url)
  */
 function valid_jsonp_callback($callback)
 {
-    return !preg_match( '/[^0-9a-zA-Z\$_]|^(abstract|boolean|break|byte|case|catch|char|class|const|continue|debugger|default|delete|do|double|else|enum|export|extends|false|final|finally|float|for|function|goto|if|implements|import|in|instanceof|int|interface|long|native|new|null|package|private|protected|public|return|short|static|super|switch|synchronized|this|throw|throws|transient|true|try|typeof|var|volatile|void|while|with|NaN|Infinity|undefined)$/', $callback);
+	/*
+	 * JSONP callback names must be valid JavaScript identifiers and not reserved words.
+	 * This uses an allowlist approach rather than denylist to be more secure.
+	 * Valid: alphanumeric, underscore, dollar sign. Cannot start with digit.
+	 * Cannot be JavaScript reserved words.
+	 */
+	if (empty($callback) || strlen($callback) > 255)
+	{
+		return false;
+	}
+	
+	/*
+	 * Must be a valid JavaScript identifier.
+	 */
+	if (!preg_match('/^[a-zA-Z_$][a-zA-Z0-9_$]*$/', $callback))
+	{
+		return false;
+	}
+	
+	/*
+	 * Reject JavaScript reserved words and built-in global objects.
+	 */
+	$reserved = [
+		'abstract', 'arguments', 'await', 'boolean', 'break', 'byte', 'case', 'catch',
+		'char', 'class', 'const', 'continue', 'debugger', 'default', 'delete', 'do',
+		'double', 'else', 'enum', 'eval', 'export', 'extends', 'false', 'final',
+		'finally', 'float', 'for', 'function', 'goto', 'if', 'implements', 'import',
+		'in', 'instanceof', 'int', 'interface', 'let', 'long', 'native', 'new', 'null',
+		'package', 'private', 'protected', 'public', 'return', 'short', 'static',
+		'super', 'switch', 'synchronized', 'this', 'throw', 'throws', 'transient',
+		'true', 'try', 'typeof', 'var', 'void', 'volatile', 'while', 'with', 'yield',
+		'NaN', 'Infinity', 'undefined', 'window', 'document', 'console', 'alert'
+	];
+	
+	if (in_array(strtolower($callback), $reserved, true))
+	{
+		return false;
+	}
+	
+	return true;
 }
 
 
@@ -108,10 +147,9 @@ function json_error($text)
 	$error = json_encode($error);
 
 	/*
-	 * Return a 400 "Bad Request" error. This indicates that the request was invalid. Whether this
-	 * is the best HTTP header is subject to debate.
+	 * Return a 400 "Bad Request" error. This indicates that the request was invalid.
 	 */
-	header("HTTP/1.0 400 OK");
+	header("HTTP/1.0 400 Bad Request");
 
 	/*
 	 * Send an HTTP header defining the content as JSON.


### PR DESCRIPTION
- Replace dangerous extract() calls with explicit variable assignment
  * class.BaseController.inc.php: Explicit loop instead of extract() in render()
  * class.LawController.inc.php: Explicit loop instead of extract() in handle()
  * class.StructureController.inc.php: Explicit loop instead of extract() in handle()
  * class.MasterController.inc.php: Explicit loop instead of extract() in execute()

- Fix incorrect HTTP status code
  * functions.inc.php: Change 'HTTP/1.0 400 OK' to 'HTTP/1.0 400 Bad Request'

- Improve JSONP callback validation
  * functions.inc.php: Replace regex-based validation with explicit allowlist approach
  * Add reserved words and built-in globals
  * Enforce 255 character limit
  * Validate with proper JavaScript identifier rules

These changes prevent:
- Variable hijacking through extract()
- XSS via JSONP callback bypass
- HTTP header confusion attacks